### PR TITLE
Add application name

### DIFF
--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,6 +1,5 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "PixelogicDev",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
Adding app `name` "PixelogicDev".

`shortname` is normally only used when the name of the application is longer than 12 characters (more than that and it is truncated in Chrome). It so happens that "PixelogicDev" is exactly 12 characters so `shortname` would be superfluous.

https://developer.chrome.com/apps/manifest/name
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name
